### PR TITLE
BitwardenSecret CRD for Managing Kubernetes Secrets

### DIFF
--- a/helm/crds/bitwardensecret.yaml
+++ b/helm/crds/bitwardensecret.yaml
@@ -87,31 +87,5 @@ spec:
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
-            properties:
-              secret:
-                type: object
-                properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    type: string
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                  resourceVersion:
-                    type: string
-                  uid:
-                    type: string
-              lastSync:
-                type: string
-                format: date-time
-                description: "The date and time of the last successful synchronization with Bitwarden."
-              lastSyncStatus:
-                type: string
-                description: "Status of the last synchronization attempt (e.g., 'Success', 'Failed')."
-              lastErrorMessage:
-                type: string
-                description: "Detailed error message in case of failure in the last synchronization."
     served: true
     storage: true

--- a/helm/crds/bitwardensecret.yaml
+++ b/helm/crds/bitwardensecret.yaml
@@ -1,30 +1,20 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: bitwardensyncconfigs.bitwarden-k8s-secrets-manager.demo.redhat.com
+  name: bitwardensecrets.bitwarden-k8s-secrets-manager.demo.redhat.com
 spec:
   group: bitwarden-k8s-secrets-manager.demo.redhat.com
-  scope: Namespaced
   names:
-    plural: bitwardensyncconfigs
-    singular: bitwardensyncconfig
-    kind: BitwardenSyncConfig
+    kind: BitwardenSecret
+    listKind: BitwardenSecretList
+    plural: bitwardensecrets
+    singular: bitwardensecret
+  scope: Namespaced
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
-        description: >-
-          Configuration for bitwarden-k8s-secrets-manager 
         type: object
-        required:
-        - apiVersion
-        - kind
-        - metadata
-        - spec
         properties:
           apiVersion:
             type: string
@@ -32,23 +22,9 @@ spec:
             type: string
           metadata:
             type: object
-            properties:
-              name:
-                type: string
-                maxLength: 63
-                pattern: ^[a-z0-9\-]*[a-z0-9]$
           spec:
-            description: >-
-              Bitwarden Secrets synchronization settings.
             type: object
             properties:
-              accessTokenSecret:
-                type: object
-                properties:
-                  name:
-                    type: string
-                required:
-                - name
               secrets:
                 type: array
                 items:
@@ -108,10 +84,34 @@ spec:
                       type: string
                     type:
                       type: string
-              syncInterval:
-                minimum: 10
-                type: integer
-
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
+            properties:
+              secret:
+                type: object
+                properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  resourceVersion:
+                    type: string
+                  uid:
+                    type: string
+              lastSync:
+                type: string
+                format: date-time
+                description: "The date and time of the last successful synchronization with Bitwarden."
+              lastSyncStatus:
+                type: string
+                description: "Status of the last synchronization attempt (e.g., 'Success', 'Failed')."
+              lastErrorMessage:
+                type: string
+                description: "Detailed error message in case of failure in the last synchronization."
+    served: true
+    storage: true

--- a/helm/crds/bitwardensecret.yaml
+++ b/helm/crds/bitwardensecret.yaml
@@ -80,10 +80,6 @@ spec:
                         - secret
                     name:
                       type: string
-                    namespace:
-                      type: string
-                    type:
-                      type: string
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/helm/templates/clusterrole.yaml
+++ b/helm/templates/clusterrole.yaml
@@ -11,6 +11,8 @@ rules:
   resources:
   - bitwardensyncconfigs
   - bitwardensyncconfigs/status
+  - bitwardensecrets
+  - bitwardensecrets/status
   verbs:
   - create
   - delete

--- a/operator/bitwardensecret.py
+++ b/operator/bitwardensecret.py
@@ -1,0 +1,211 @@
+import os
+from base64 import b64encode, b64decode
+import kubernetes_asyncio
+from k8sutil import CachedK8sObject, K8sUtil
+from bitwardensyncconfig import BitwardenSyncError, BitwardenSyncConfigSecret, BitwardenSecrets as BitwardenSecretsUtil
+
+
+class BitwardenSecrets(CachedK8sObject):
+    api_group = K8sUtil.operator_domain
+    api_version = K8sUtil.operator_version
+    kind = 'BitwardenSecret'
+    plural = 'bitwardensecrets'
+
+    api_group_version = f"{api_group}/{api_version}"
+    cache = {}
+    sync_config_label = os.environ.get('MANAGED_SECRET_LABEL', f"{K8sUtil.operator_domain}/bitwarden-secret")
+    # TODO: Make this configurable
+    secret_access_token_secret_name = os.environ.get('SECRET_TOKEN_NAME', 'bitwarden-access-token')
+    operator_namespace = os.environ.get('OPERATOR_NAMESPACE', 'bitwarden-dev')
+
+    @classmethod
+    async def on_create(cls, logger, **kwargs):
+        secret = cls.register(**kwargs)
+        await secret.sync_secret(logger=logger)
+
+    @classmethod
+    async def on_delete(cls, logger, **kwargs):
+        secret = cls.register(**kwargs)
+        await secret.delete_secret(logger=logger)
+
+    @classmethod
+    async def on_resume(cls, logger, **kwargs):
+        secret = cls.register(**kwargs)
+        await secret.sync_secret(logger=logger)
+
+    @classmethod
+    async def on_update(cls, logger, **kwargs):
+        secret = cls.register(**kwargs)
+        await secret.sync_secret(logger=logger)
+
+    @property
+    def owner_references(self):
+        return kubernetes_asyncio.client.V1OwnerReference(
+            api_version=self.api_group_version,
+            kind="BitwardenSecret",
+            name=self.name,
+            uid=self.meta.uid,
+            controller=True,
+            )
+
+    @property
+    def secrets(self):
+        return [
+            BitwardenSyncConfigSecret(item) for item in self.spec.get("secrets", [])
+        ]
+
+    @property
+    def sync_config_value(self):
+        return f"{self.namespace}.{self.name}"
+
+    @property
+    def sync_interval(self):
+        return self.spec.get('syncInterval', 30)
+
+    @property
+    def uid(self):
+        return self.meta.get('uid')
+
+    async def check_delete_secret(self, name, namespace):
+        secret = None
+        try:
+            secret = await K8sUtil.core_v1_api.read_namespaced_secret(
+                name=name,
+                namespace=namespace,
+            )
+        except kubernetes_asyncio.client.rest.ApiException as err:
+            if err.status == 404:
+                return None, None
+            raise
+
+        if (
+            not secret.metadata.labels or
+            secret.metadata.labels['app.kubernetes.io/managed-by'] != 'bitwarden-k8s-secrets-manager' or
+            secret.metadata.labels[self.sync_config_label] != self.sync_config_value
+        ):
+            return secret, False
+
+        try:
+            secret = await K8sUtil.core_v1_api.delete_namespaced_secret(
+                name=name,
+                namespace=namespace,
+            )
+        except kubernetes_asyncio.client.rest.ApiException as err:
+            if err.status != 404:
+                raise
+        return secret, True
+
+    async def get_access_token(self):
+        try:
+            token_secret = await K8sUtil.core_v1_api.read_namespaced_secret(
+                name=self.secret_access_token_secret_name,
+                namespace=self.operator_namespace,
+            )
+        except kubernetes_asyncio.client.rest.ApiException as err:
+            if err.status == 404:
+                raise BitwardenSyncError(
+                    f"Bitwarden access token secret '{self.secret_access_token_secret_name}' not found"
+                ) from err
+            raise
+
+        if 'token' not in token_secret.data:
+            raise BitwardenSyncError(
+                f"Bitwarden access token secret '{self.secret_access_token_secret_name}' missing data.token"
+            )
+
+        return b64decode(token_secret.data['token']).decode('utf-8')
+
+    async def get_bitwarden_secrets(self):
+        bitwarden_access_token = await self.get_access_token()
+        return await BitwardenSecretsUtil.get(access_token=bitwarden_access_token)
+
+    async def get_secret_info(self, secret):
+        return {
+            "apiVersion": 'v1',
+            "kind": "Secret",
+            "name": secret.metadata.name,
+            "namespace": secret.metadata.namespace,
+            "uid": secret.metadata.uid,
+            }
+
+    async def sync_secrets(self, logger):
+        try:
+            bitwarden_secrets = await self.get_bitwarden_secrets()
+        except BitwardenSyncError as err:
+            logger.error(f"Failed getting Bitwarden secrets for {self}: {err}")
+            return
+        for secret_config in self.secrets:
+            namespace = secret_config.namespace or self.namespace
+            try:
+                data = {
+                    key: b64encode(value.encode('utf-8')).decode('utf-8')
+                    for key, value in bitwarden_secrets.get_values(secret_config.data).items()
+                }
+                annotations = bitwarden_secrets.get_values(secret_config.annotations)
+                labels = bitwarden_secrets.get_values(secret_config.labels)
+                labels[self.sync_config_label] = self.sync_config_value
+
+                secret = None
+                try:
+                    secret = await K8sUtil.core_v1_api.read_namespaced_secret(
+                        name=secret_config.name,
+                        namespace=namespace,
+                    )
+                except kubernetes_asyncio.client.rest.ApiException as err:
+                    if err.status != 404:
+                        raise BitwardenSyncError(f"Error {err.status} getting secret: {err}") from err
+
+                if secret:
+                    is_managed = any(
+                        owner_ref.uid == self.uid and
+                        owner_ref.kind == self.kind and
+                        owner_ref.api_version == self.api_version
+                        for owner_ref in secret.metadata.owner_references or []
+                        )
+
+                    if not is_managed:
+                        raise BitwardenSyncError(
+                            f"{secret_config} is not owned by {self}"
+                        )
+
+                    if (
+                        secret.data != data or
+                        (secret.metadata.annotations or {}) != annotations or
+                        (secret.metadata.labels or {}) != labels or
+                        secret.type != secret_config.type
+                    ):
+                        secret.data = data
+                        secret.metadata.annotations = annotations
+                        secret.metadata.labels = labels
+                        secret.type = secret_config.type
+
+                        secret = await K8sUtil.core_v1_api.replace_namespaced_secret(
+                            body=secret,
+                            name=secret_config.name,
+                            namespace=namespace,
+                        )
+                        logger.info(f"Updated {secret_config} for {self}")
+                else:
+                    secret = await K8sUtil.core_v1_api.create_namespaced_secret(
+                        body=kubernetes_asyncio.client.V1Secret(
+                            data=data,
+                            metadata=kubernetes_asyncio.client.V1ObjectMeta(
+                                annotations=annotations,
+                                name=secret_config.name,
+                                labels=labels,
+                                owner_references=[self.owner_references],
+                            ),
+                            type=secret_config.type,
+                        ),
+                        namespace=namespace,
+                    )
+
+                    logger.info(f"Created {secret_config} for {self}")
+
+            except BitwardenSyncError as err:
+                logger.error(f"Failed to sync {secret_config} for {self}: {err}")
+            except Exception as err:
+                logger.exception(f"Error syncing {secret_config} for {self}: {err}")
+
+    async def delete_secret(self, logger):
+        pass

--- a/operator/bitwardensyncconfig.py
+++ b/operator/bitwardensyncconfig.py
@@ -348,6 +348,14 @@ class BitwardenSecrets:
             elif src.secret:
                 if src.secret not in self.secrets_dict:
                     raise BitwardenSyncError(f"No Bitwarden secret {src.secret}")
+
+                bitwarden_secret = self.secrets_dict[src.secret]
+                value = bitwarden_secret.value
+
+                if hasattr(src, 'project') and src.project:
+                    if not hasattr(bitwarden_secret, 'project') or bitwarden_secret.project != src.project:
+                        raise BitwardenSyncError(f"Project mismatch for secret {src.secret}.{src.key}")
+
                 value = self.secrets_dict[src.secret].value
                 if src.key:
                     if not isinstance(value, dict):


### PR DESCRIPTION
The **BitwardenSecret** CRD enables Kubernetes to automatically fetch secrets from Bitwarden and create corresponding Kubernetes secrets. This integration simplifies secret synchronization between Bitwarden and Kubernetes, enhancing security and streamlining secret management in Kubernetes environments.

**Key Features**
**Bitwarden Integration**: Fetches secrets directly from Bitwarden Secret Manager based on the configurations defined in the BitwardenSecret resource.
**Automatic Secret Synchronization**: Creates and updates Kubernetes secrets automatically, mirroring the secrets stored in Bitwarden.
**Lifecycle Management**: Utilizes Kubernetes finalizers for proper cleanup of Kubernetes secrets when a BitwardenSecret resource is deleted, preventing orphaned resources.

**Example Configuration**
Below is an example configuration of a BitwardenSecret object, demonstrating the integration with Bitwarden Secret Manager:

```yaml
apiVersion: bitwarden-k8s-secrets-manager.demo.redhat.com/v1
kind: BitwardenSecret
metadata:
  name: example-bitwarden-secret
  namespace: bitwarden-dev
spec:
  secrets:
    - name: database
      data:
        hostname:
          key: hostname
          project: project_name
          secret: reporting_database
        password:
          key: password
          project: project_name
          secret: reporting_database
      labels:
        demo.redhat.com/database-hostname:
          key: hostname
          secret: reporting_database
```