### PR TITLE
Helm: add extraEnvs to be able to define env in deployment

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
       - name: operator
         image: {{ include "bitwarden-k8s-secrets-manager.image" . | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.extraEnvs }}
+        env:
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         livenessProbe:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -45,6 +45,12 @@ resources:
     cpu: 500m
     memory: 128Mi
 
+# Additional environment variables to pass to bitwarden-k8s-secrets-manager
+# extraEnvs:
+# - name: BWS_SERVER_URL
+#   value: https://vault.bitwarden.eu
+extraEnvs: []
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
A small contribution to fix https://github.com/rhpds/bitwarden-k8s-secrets-manager/issues/14

Add a `extraEnvs` value to be able to define env in deployment. I chose this name because it's a common name in helm charts, even though it's not really _extra_ as it adds the `env` key. But this way you could refactor the deployment and add configurations without changing this key in the values.
